### PR TITLE
Added default props for style. Empty style raised error before

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,4 +21,8 @@ ScalableText.propTypes = {
   children: PropTypes.node.isRequired
 };
 
+ScalableText.defaultProps = {
+  style: {}
+};
+
 export default ScalableText;


### PR DESCRIPTION
`<ScalableText>Test<ScalableText/>` raised error and I needed to set `<ScalableText style= {{}}>Test<ScalableText/>` to avoid it.