### PR TITLE
use real width

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 import React, { PropTypes } from 'react';
 import { Dimensions, Text, StyleSheet } from 'react-native';
-
+const { width, height } = Dimensions.get('window');
 const flattenStyle = StyleSheet.flatten;
-
+const realWidth = height > width ? width : height;
 
 const ScalableText = ({ style, children, ...props }) => {
   const fontSize = flattenStyle(style).fontSize || 14;
-  const { width } = Dimensions.get('window');
-  const scaledFontSize = Math.round(fontSize * width / 375);
+  const scaledFontSize = Math.round(fontSize * realWidth / 375);
 
   return (
     <Text style={[style, { fontSize: scaledFontSize }]} {...props}>


### PR DESCRIPTION
if app is in landscape mode it should use `height` from `Dimensions.get('window')` instead of `width`

Also this pull request move `Dimensions.get..` from render 