### PR TITLE
Add support for React 16

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Dimensions, Text, StyleSheet } from 'react-native';
 const { width, height } = Dimensions.get('window');
 const flattenStyle = StyleSheet.flatten;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/knowbody/react-native-text#readme",
   "peerDependencies": {
+    "prop-types": "*",
     "react": "*",
     "react-native": "*"
   }


### PR DESCRIPTION
This PR fixes the `PropTypes` import to add support for the `React 16`.