### PR TITLE
Update PropType definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,10 @@ const ScalableText = ({ style, children, ...props }) => {
 
 ScalableText.propTypes = {
   style: Text.propTypes.style,
-  children: PropTypes.node.isRequired
+  children:PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string
+  ]).isRequired
 };
 
 ScalableText.defaultProps = {


### PR DESCRIPTION
This PR updates the `children` PropTypes definitions to consider a scenario where a simple string is used as children. 