### PR TITLE
Added types for children and styles

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,8 @@ import { TextProps as BaseTextProps } from 'react-native';
 
 export interface TextProps extends BaseTextProps {
   deviceBaseWidth?: number;
+  style?: any;
+  children: string;
 }
 
 export interface ScaledStyles {


### PR DESCRIPTION
Tslint was complaining because these were missing. 
Not sure whether your intention it to allow nested elements within the tag, if so you might want to change the type from String.