### PR TITLE
fix: exported types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "react-native": "lib/module/index.js",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "files": [
     "lib/",
     "src/"


### PR DESCRIPTION
Thanks for writing this library! It works great, but typescript doesn't pick up the exported types. I tested this change locally and it fixed it for our project.

Fixes #24 